### PR TITLE
feat: Adds op-batcher restart policy

### DIFF
--- a/ops-optimium/docker-compose.yml
+++ b/ops-optimium/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     depends_on:
       - op-geth
       - op-node
+    restart: on-failure
     build:
       context: ../
       dockerfile: ./op-batcher/Dockerfile


### PR DESCRIPTION
# Change 
- [x] Adds op-batcher restart policy

# Reason for change
This introduces an automatic restart policy on op-batcher container whenever crashed.
Once op-batcher container is created op-node container gets recreated (still need to troubleshoot why).


# Tests

```
╰─$ docker ps -a 
CONTAINER ID   IMAGE                      COMMAND                  CREATED         STATUS         PORTS                                                                                                                                                                        NAMES
6a864953b4de   ops-optimium-op-proposer   "op-proposer"            5 minutes ago   Up 5 minutes   0.0.0.0:6062->6060/tcp, :::6062->6060/tcp, 0.0.0.0:7302->7300/tcp, :::7302->7300/tcp                                                                                         ops-optimium-op-proposer-1
a16ba94b385e   ops-optimium-op-batcher    "op-batcher --l2-eth…"   5 minutes ago   Up 5 minutes   0.0.0.0:6061->6060/tcp, :::6061->6060/tcp, 0.0.0.0:7301->7300/tcp, :::7301->7300/tcp, 0.0.0.0:6545->8545/tcp, :::6545->8545/tcp                                              ops-optimium-op-batcher-1
e3fc62d1b869   ops-optimium-op-node       "op-node --l2=http:/…"   5 minutes ago   Up 5 minutes   0.0.0.0:6060->6060/tcp, :::6060->6060/tcp, 0.0.0.0:7300->7300/tcp, :::7300->7300/tcp, 0.0.0.0:9003->9003/tcp, :::9003->9003/tcp, 0.0.0.0:7545->8545/tcp, :::7545->8545/tcp   ops-optimium-op-node-1
e46f6ce9c8c6   ops-optimium-op-geth       "/bin/sh /entrypoint…"   5 minutes ago   Up 5 minutes   8546/tcp, 30303/tcp, 30303/udp, 0.0.0.0:8060->6060/tcp, :::8060->6060/tcp, 0.0.0.0:9545->8545/tcp, :::9545->8545/tcp                                                         ops-optimium-op-geth-1

```